### PR TITLE
Add Optional PersonModel to RollbarClient

### DIFF
--- a/src/RollbarSharp/Builders/DataModelBuilder.cs
+++ b/src/RollbarSharp/Builders/DataModelBuilder.cs
@@ -20,10 +20,10 @@ namespace RollbarSharp.Builders
             Configuration = configuration;
         }
 
-        public DataModel CreateExceptionNotice(Exception ex, string message = null, string level = "error")
+        public DataModel CreateExceptionNotice(Exception ex, string message = null, string level = "error", PersonModel personModel=null)
         {
             var body = BodyModelBuilder.CreateExceptionBody(ex);
-            var model = Create(level, body);
+            var model = Create(level, body, personModel);
             
             // if the exception has a fingerprint property, copy it to the notice
             if (!string.IsNullOrEmpty(body.Trace.Exception.Fingerprint))
@@ -37,9 +37,9 @@ namespace RollbarSharp.Builders
             return model;
         }
 
-        public DataModel CreateMessageNotice(string message, string level = "info", IDictionary<string, object> customData = null)
+        public DataModel CreateMessageNotice(string message, string level = "info", IDictionary<string, object> customData = null, PersonModel personModel = null)
         {
-            return Create(level, BodyModelBuilder.CreateMessageBody(message, customData));
+            return Create(level, BodyModelBuilder.CreateMessageBody(message, customData), personModel);
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace RollbarSharp.Builders
         /// <param name="level"></param>
         /// <param name="body"></param>
         /// <returns></returns>
-        protected DataModel Create(string level, BodyModel body)
+        protected DataModel Create(string level, BodyModel body, PersonModel personModel)
         {
             var model = new DataModel(level, body);
             
@@ -62,8 +62,8 @@ namespace RollbarSharp.Builders
             model.Notifier = NotifierModelBuilder.CreateFromAssemblyInfo();
 
             model.Request = RequestModelBuilder.CreateFromCurrentRequest();
-            model.Server = ServerModelBuilder.CreateFromCurrentRequest();
-            model.Person = PersonModelBuilder.CreateFromCurrentRequest();
+            model.Server = ServerModelBuilder.CreateFromCurrentRequest();            
+            model.Person = personModel ?? PersonModelBuilder.CreateFromCurrentRequest();
             
             return model;
         }

--- a/src/RollbarSharp/RollbarClient.cs
+++ b/src/RollbarSharp/RollbarClient.cs
@@ -73,9 +73,9 @@ namespace RollbarSharp
         /// </summary>
         /// <param name="ex"></param>
         /// <param name="title"></param>
-        public void SendCriticalException(Exception ex, string title = null)
+        public void SendCriticalException(Exception ex, string title = null, PersonModel personModel = null)
         {
-            SendException(ex, title, "critical");
+            SendException(ex, title, "critical", personModel);
         }
 
         /// <summary>
@@ -83,9 +83,9 @@ namespace RollbarSharp
         /// </summary>
         /// <param name="ex"></param>
         /// <param name="title"></param>
-        public void SendErrorException(Exception ex, string title = null)
+        public void SendErrorException(Exception ex, string title = null, PersonModel personModel = null)
         {
-            SendException(ex, title, "error");
+            SendException(ex, title, "error", personModel);
         }
 
         /// <summary>
@@ -93,9 +93,9 @@ namespace RollbarSharp
         /// </summary>
         /// <param name="ex"></param>
         /// <param name="title"></param>
-        public void SendWarningException(Exception ex, string title = null)
+        public void SendWarningException(Exception ex, string title = null, PersonModel personModel = null)
         {
-            SendException(ex, title, "warning");
+            SendException(ex, title, "warning", personModel);
         }
 
         /// <summary>
@@ -105,9 +105,9 @@ namespace RollbarSharp
         /// <param name="ex"></param>
         /// <param name="title"></param>
         /// <param name="level">Default is "error". "critical" and "warning" may also make sense to use.</param>
-        public void SendException(Exception ex, string title = null, string level = "error")
+        public void SendException(Exception ex, string title = null, string level = "error", PersonModel personModel = null)
         {
-            var notice = NoticeBuilder.CreateExceptionNotice(ex, title, level);
+            var notice = NoticeBuilder.CreateExceptionNotice(ex, title, level, personModel);
             Send(notice);
         }
 
@@ -116,9 +116,9 @@ namespace RollbarSharp
         /// </summary>
         /// <param name="message"></param>
         /// <param name="customData"></param>
-        public void SendCriticalMessage(string message, IDictionary<string, object> customData = null)
+        public void SendCriticalMessage(string message, IDictionary<string, object> customData = null, PersonModel personModel = null)
         {
-            SendMessage(message, "critical", customData);
+            SendMessage(message, "critical", customData, personModel);
         }
 
         /// <summary>
@@ -126,9 +126,9 @@ namespace RollbarSharp
         /// </summary>
         /// <param name="message"></param>
         /// <param name="customData"></param>
-        public void SendErrorMessage(string message, IDictionary<string, object> customData = null)
+        public void SendErrorMessage(string message, IDictionary<string, object> customData = null, PersonModel personModel = null)
         {
-            SendMessage(message, "error", customData);
+            SendMessage(message, "error", customData, personModel);
         }
 
         /// <summary>
@@ -136,9 +136,9 @@ namespace RollbarSharp
         /// </summary>
         /// <param name="message"></param>
         /// <param name="customData"></param>
-        public void SendWarningMessage(string message, IDictionary<string, object> customData = null)
+        public void SendWarningMessage(string message, IDictionary<string, object> customData = null, PersonModel personModel = null)
         {
-            SendMessage(message, "warning", customData);
+            SendMessage(message, "warning", customData, personModel);
         }
 
         /// <summary>
@@ -146,9 +146,9 @@ namespace RollbarSharp
         /// </summary>
         /// <param name="message"></param>
         /// <param name="customData"></param>
-        public void SendInfoMessage(string message, IDictionary<string, object> customData = null)
+        public void SendInfoMessage(string message, IDictionary<string, object> customData = null, PersonModel personModel = null)
         {
-            SendMessage(message, "info", customData);
+            SendMessage(message, "info", customData, personModel);
         }
 
         /// <summary>
@@ -156,9 +156,9 @@ namespace RollbarSharp
         /// </summary>
         /// <param name="message"></param>
         /// <param name="customData"></param>
-        public void SendDebugMessage(string message, IDictionary<string, object> customData = null)
+        public void SendDebugMessage(string message, IDictionary<string, object> customData = null, PersonModel personModel = null)
         {
-            SendMessage(message, "debug", customData);
+            SendMessage(message, "debug", customData, personModel);
         }
 
         /// <summary>
@@ -167,9 +167,9 @@ namespace RollbarSharp
         /// <param name="message"></param>
         /// <param name="level"></param>
         /// <param name="customData"></param>
-        public void SendMessage(string message, string level, IDictionary<string, object> customData = null)
+        public void SendMessage(string message, string level, IDictionary<string, object> customData = null, PersonModel personModel = null)
         {
-            var notice = NoticeBuilder.CreateMessageNotice(message, level, customData);
+            var notice = NoticeBuilder.CreateMessageNotice(message, level, customData, personModel);
             Send(notice);
         }
 


### PR DESCRIPTION
These changes allow someone to specify a PersonModel when logging errors to RollbarClient.  This is mainly useful when the User is a custom type, you are using ASP.NET authentication and AUTH_USER doesn't have anything relevant.
