### PR TITLE
Added a HttpModule which can be used to catch exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,14 +66,23 @@ The `OnException` method could instead be used verbatim inside a `Controller` if
 ```csharp
 protected void Application_Error(object sender, EventArgs e)
 {
-    var exception = (HttpException) Server.GetLastError();
+    var exception = Server.GetLastError().GetBaseException();
 
-    if (exception.InnerException == null)
-        return;
-
-    (new RollbarClient()).SendException(filterContext.Exception);
+    (new RollbarClient()).SendException(exception);
 }
 ```
+
+
+### As an HttpModule in the Web.config
+
+```xml
+	<system.webServer>
+		<modules>
+			<add name="RollbarHttpModule" type="RollbarSharp.RollbarHttpModule"/>
+		</modules>
+	</system.webServer>
+```
+
 
 ## Bugs
 

--- a/src/RollbarSharp/RollbarHttpModule.cs
+++ b/src/RollbarSharp/RollbarHttpModule.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Web;
+
+namespace RollbarSharp
+{
+  public class RollbarHttpModule : IHttpModule
+  {
+    public void Init(HttpApplication context)
+    {
+      context.Error += SendError;
+    }
+
+    public void Dispose()
+    {
+    }
+
+    private void SendError(object sender, EventArgs e)
+    {
+      var application = (HttpApplication)sender;
+      new RollbarClient().SendException(application.Server.GetLastError().GetBaseException());
+    }
+    
+  }
+}

--- a/src/RollbarSharp/RollbarSharp.csproj
+++ b/src/RollbarSharp/RollbarSharp.csproj
@@ -55,6 +55,7 @@
     <Compile Include="RequestStartingEventArgs.cs" />
     <Compile Include="Result.cs" />
     <Compile Include="RollbarClient.cs" />
+    <Compile Include="RollbarHttpModule.cs" />
     <Compile Include="Serialization\BodyModel.cs" />
     <Compile Include="Serialization\ExceptionBodyModel.cs" />
     <Compile Include="Serialization\ExceptionModel.cs" />


### PR DESCRIPTION
A HttpModule which makes it a little easier to drop Rollbar into your
project without touching your code. I also changed the README.md code
example to use GetBaseException() as I believe this already unwraps the
exception to the most inner exception.
