### PR TITLE
Added extension method .ToRollbar

### DIFF
--- a/src/RollbarSharp/ExceptionExtension.cs
+++ b/src/RollbarSharp/ExceptionExtension.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace RollbarSharp
+{
+    /// <summary>
+    /// Provides extension methods for .net Exceptions
+    /// </summary>
+	public static class ExceptionExtension
+	{
+        /// <summary>
+        /// Adds the <see cref="Exception"/> instance to Rollbar
+        /// </summary>
+        /// <param name="exception">The exception.</param>
+		public static void ToRollbar (this Exception exception)
+		{
+            if (exception != null)
+            {
+                (new RollbarClient()).SendException(exception);
+            }
+		}
+	}
+}
+

--- a/src/RollbarSharp/RollbarSharp.csproj
+++ b/src/RollbarSharp/RollbarSharp.csproj
@@ -11,6 +11,8 @@
     <AssemblyName>RollbarSharp</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <ProductVersion>12.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -34,10 +36,10 @@
       <HintPath>..\packages\Newtonsoft.Json.5.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Routing" />
+    <Reference Include="System.Configuration" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Builders\BodyModelBuilder.cs" />
@@ -68,6 +70,7 @@
     <Compile Include="Serialization\RequestModel.cs" />
     <Compile Include="Serialization\ServerModel.cs" />
     <Compile Include="Serialization\TraceModel.cs" />
+    <Compile Include="ExceptionExtension.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -80,4 +83,5 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <ItemGroup />
 </Project>


### PR DESCRIPTION
It extends the .net base Exception class and should
thus enable users to run "exception.ToRollbar()" to add
an exception, rather than the "(new RollbarClient).SendException"
approach.