### PR TITLE
update NewtonSoft Json to 6.0.2

### DIFF
--- a/src/RollbarSharp.Mvc4Test/RollbarSharp.Mvc4Test.csproj
+++ b/src/RollbarSharp.Mvc4Test/RollbarSharp.Mvc4Test.csproj
@@ -63,7 +63,7 @@
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.4.5.6\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.2\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http">
       <Private>True</Private>

--- a/src/RollbarSharp.Mvc4Test/packages.config
+++ b/src/RollbarSharp.Mvc4Test/packages.config
@@ -9,5 +9,5 @@
   <package id="Microsoft.AspNet.WebPages" version="2.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net40" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="4.5.6" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="6.0.2" targetFramework="net40" />
 </packages>

--- a/src/RollbarSharp/RollbarSharp.csproj
+++ b/src/RollbarSharp/RollbarSharp.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.5.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.2\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
@@ -74,7 +74,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/RollbarSharp/packages.config
+++ b/src/RollbarSharp/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="5.0.3" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="6.0.2" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Updated package config and project files to use Newtonsoft.JSON v6.0.2 instead of 5.0.3
