### PR TITLE
Capture IP address of application sending report

### DIFF
--- a/src/RollbarSharp/Serialization/RequestModel.cs
+++ b/src/RollbarSharp/Serialization/RequestModel.cs
@@ -68,6 +68,9 @@ namespace RollbarSharp.Serialization
             Parameters = new Dictionary<string, string>();
             QueryStringParameters = new Dictionary<string, string>();
             PostParameters = new Dictionary<string, string>();
+
+            // Ask Rollbar to capture the IP address of the application sending the report
+            UserIp = "$remote_ip";
         }
     }
 }


### PR DESCRIPTION
By default Rollbar doesn't capture the IP address of the application sending the report. Override this behavior so that the IP address is captured unless the sender decides to set its value directly.
