### PR TITLE
Don't bundle NewtonSoft.Json

### DIFF
--- a/build/rakefile.rb
+++ b/build/rakefile.rb
@@ -103,7 +103,6 @@ task :copy do
   destDir = File.join(PUBLISH_DIR, 'lib/net40/')
   mkdir_p(destDir)
   cp_r(File.join(BIN_DIR, "RollbarSharp.dll"), destDir)
-  cp_r(File.join(BIN_DIR, "Newtonsoft.Json.dll"), destDir)
 end
 
 desc "Create the nuget package"


### PR DESCRIPTION
NewtonSoft.Json is already expressed as a dependency.

This should stop the hint path in project files being updated to the bundled copy when it should be pointing to the (newer) NewtonSoft.Json assembly that was resolved and downloaded as a dependency.

A possible alternative fix for this would be adding a references directive to the nuspec file restricting the provided assemblies to Rollbar.Sharp.dll.