### PR TITLE
Send methods return the http request Task object for blocking

### DIFF
--- a/src/RollbarSharp.Tests/RollbarClientTest.cs
+++ b/src/RollbarSharp.Tests/RollbarClientTest.cs
@@ -1,5 +1,10 @@
 ﻿using System;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
 using NUnit.Framework;
+using RollbarSharp.Builders;
 
 namespace RollbarSharp.Tests
 {
@@ -39,6 +44,141 @@ namespace RollbarSharp.Tests
             var serialized = client.Serialize(notice);
 
             Assert.IsNotNullOrEmpty(serialized);
+        }
+
+        [Test]
+        public void when_calling_send_exception_task_returns_and_can_be_used()
+        {
+            var client = new RollbarClient();
+            Exception exception = new NotImplementedException();
+
+            var task = client.SendException(exception);
+
+            Assert.IsNotNull(task);
+            Assert.DoesNotThrow(() => task.Wait(0));
+        }
+
+        [Test]
+        public void when_calling_send_critical_exception_task_returns_and_can_be_used()
+        {
+            var client = new RollbarClient();
+            Exception exception = new NotImplementedException();
+
+            var task = client.SendCriticalException(exception);
+
+            Assert.IsNotNull(task);
+            Assert.DoesNotThrow(() => task.Wait(0));
+        }
+
+        
+        [Test]
+        public void when_calling_send_error_exception_task_returns_and_can_be_used()
+        {
+            var client = new RollbarClient();
+            Exception exception = new NotImplementedException();
+
+            var task = client.SendErrorException(exception);
+
+            Assert.IsNotNull(task);
+            Assert.DoesNotThrow(() => task.Wait(0));
+        }
+
+        [Test]
+        public void when_calling_send_warning_exception_task_returns_and_can_be_used()
+        {
+            var client = new RollbarClient();
+            Exception exception = new NotImplementedException();
+
+            var task = client.SendWarningException(exception);
+
+            Assert.IsNotNull(task);
+            Assert.DoesNotThrow(() => task.Wait(0));
+        }
+
+        [Test]
+        public void when_calling_send_critical_message_task_returns_and_can_be_used()
+        {
+            var client = new RollbarClient();
+            var message = "";
+
+            var task = client.SendCriticalMessage(message);
+
+            Assert.IsNotNull(task);
+            Assert.DoesNotThrow(() => task.Wait(0));
+        }
+
+        [Test]
+        public void when_calling_send_error_message_task_returns_and_can_be_used()
+        {
+            var client = new RollbarClient();
+            var message = "";
+
+            var task = client.SendErrorMessage(message);
+
+            Assert.IsNotNull(task);
+            Assert.DoesNotThrow(() => task.Wait(0));
+        }
+
+        [Test]
+        public void when_calling_send_warning_message_task_returns_and_can_be_used()
+        {
+            var client = new RollbarClient();
+            var message = "";
+
+            var task = client.SendWarningMessage(message);
+
+            Assert.IsNotNull(task);
+            Assert.DoesNotThrow(() => task.Wait(0));
+        }
+
+        [Test]
+        public void when_calling_send_info_message_task_returns_and_can_be_used()
+        {
+            var client = new RollbarClient();
+            var message = "";
+
+            var task = client.SendInfoMessage(message);
+
+            Assert.IsNotNull(task);
+            Assert.DoesNotThrow(() => task.Wait(0));
+        }
+
+        [Test]
+        public void when_calling_send_debug_message_task_returns_and_can_be_used()
+        {
+            var client = new RollbarClient();
+            var message = "";
+
+            var task = client.SendDebugMessage(message);
+
+            Assert.IsNotNull(task);
+            Assert.DoesNotThrow(() => task.Wait(0));
+        }
+
+        [Test]
+        public void when_calling_send_message_task_returns_and_can_be_used()
+        {
+            var client = new RollbarClient();
+            var message = "";
+
+            var task = client.SendMessage(message, "info");
+
+            Assert.IsNotNull(task);
+            Assert.DoesNotThrow(() => task.Wait(0));
+        }
+
+        [Test]
+        public void when_calling_send_task_returns_and_can_be_used()
+        {
+            var client = new RollbarClient();
+            var message = "";
+            
+            var notice = new DataModelBuilder().CreateMessageNotice(message, "debug");
+
+            var task = client.Send(notice, null);
+
+            Assert.IsNotNull(task);
+            Assert.DoesNotThrow(() => task.Wait(0));
         }
     }
 }

--- a/src/RollbarSharp/IRollbarClient.cs
+++ b/src/RollbarSharp/IRollbarClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using RollbarSharp.Builders;
 using RollbarSharp.Serialization;
 
@@ -31,7 +32,8 @@ namespace RollbarSharp
         /// <param name="ex"></param>
         /// <param name="title"></param>
         /// <param name="modelAction"></param>
-        void SendCriticalException(Exception ex, string title = null, Action<DataModel> modelAction = null, object userParam = null);
+        /// <param name="userParam"></param>
+        Task SendCriticalException(Exception ex, string title = null, Action<DataModel> modelAction = null, object userParam = null);
 
         /// <summary>
         /// Sends an exception using the "error" level
@@ -39,7 +41,8 @@ namespace RollbarSharp
         /// <param name="ex"></param>
         /// <param name="title"></param>
         /// <param name="modelAction"></param>
-        void SendErrorException(Exception ex, string title = null, Action<DataModel> modelAction = null, object userParam = null);
+        /// <param name="userParam"></param>
+        Task SendErrorException(Exception ex, string title = null, Action<DataModel> modelAction = null, object userParam = null);
 
         /// <summary>
         /// Sents an exception using the "warning" level
@@ -47,7 +50,8 @@ namespace RollbarSharp
         /// <param name="ex"></param>
         /// <param name="title"></param>
         /// <param name="modelAction"></param>
-        void SendWarningException(Exception ex, string title = null, Action<DataModel> modelAction = null, object userParam = null);
+        /// <param name="userParam"></param>
+        Task SendWarningException(Exception ex, string title = null, Action<DataModel> modelAction = null, object userParam = null);
 
         /// <summary>
         /// Sends the given <see cref="Exception"/> to Rollbar including
@@ -57,7 +61,8 @@ namespace RollbarSharp
         /// <param name="title"></param>
         /// <param name="level">Default is "error". "critical" and "warning" may also make sense to use.</param>
         /// <param name="modelAction"></param>
-        void SendException(Exception ex, string title = null, string level = "error", Action<DataModel> modelAction = null, object userParam = null);
+        /// <param name="userParam"></param>
+        Task SendException(Exception ex, string title = null, string level = "error", Action<DataModel> modelAction = null, object userParam = null);
 
         /// <summary>
         /// Sends a text notice using the "critical" level
@@ -65,7 +70,8 @@ namespace RollbarSharp
         /// <param name="message"></param>
         /// <param name="customData"></param>
         /// <param name="modelAction"></param>
-        void SendCriticalMessage(string message, IDictionary<string, object> customData = null, Action<DataModel> modelAction = null, object userParam = null);
+        /// <param name="userParam"></param>
+        Task SendCriticalMessage(string message, IDictionary<string, object> customData = null, Action<DataModel> modelAction = null, object userParam = null);
 
         /// <summary>
         /// Sents a text notice using the "error" level
@@ -73,7 +79,8 @@ namespace RollbarSharp
         /// <param name="message"></param>
         /// <param name="customData"></param>
         /// <param name="modelAction"></param>
-        void SendErrorMessage(string message, IDictionary<string, object> customData = null, Action<DataModel> modelAction = null, object userParam = null);
+        /// <param name="userParam"></param>
+        Task SendErrorMessage(string message, IDictionary<string, object> customData = null, Action<DataModel> modelAction = null, object userParam = null);
 
         /// <summary>
         /// Sends a text notice using the "warning" level
@@ -81,7 +88,8 @@ namespace RollbarSharp
         /// <param name="message"></param>
         /// <param name="customData"></param>
         /// <param name="modelAction"></param>
-        void SendWarningMessage(string message, IDictionary<string, object> customData = null, Action<DataModel> modelAction = null, object userParam = null);
+        /// <param name="userParam"></param>
+        Task SendWarningMessage(string message, IDictionary<string, object> customData = null, Action<DataModel> modelAction = null, object userParam = null);
 
         /// <summary>
         /// Sends a text notice using the "info" level
@@ -89,7 +97,8 @@ namespace RollbarSharp
         /// <param name="message"></param>
         /// <param name="customData"></param>
         /// <param name="modelAction"></param>
-        void SendInfoMessage(string message, IDictionary<string, object> customData = null, Action<DataModel> modelAction = null, object userParam = null);
+        /// <param name="userParam"></param>
+        Task SendInfoMessage(string message, IDictionary<string, object> customData = null, Action<DataModel> modelAction = null, object userParam = null);
 
         /// <summary>
         /// Sends a text notice using the "debug" level
@@ -97,7 +106,8 @@ namespace RollbarSharp
         /// <param name="message"></param>
         /// <param name="customData"></param>
         /// <param name="modelAction"></param>
-        void SendDebugMessage(string message, IDictionary<string, object> customData = null, Action<DataModel> modelAction = null, object userParam = null);
+        /// <param name="userParam"></param>
+        Task SendDebugMessage(string message, IDictionary<string, object> customData = null, Action<DataModel> modelAction = null, object userParam = null);
 
         /// <summary>
         /// Sents a text notice using the given level of severity
@@ -106,9 +116,10 @@ namespace RollbarSharp
         /// <param name="level"></param>
         /// <param name="customData"></param>
         /// <param name="modelAction"></param>
-        void SendMessage(string message, string level, IDictionary<string, object> customData = null, Action<DataModel> modelAction = null, object userParam = null);
+        /// <param name="userParam"></param>
+        Task SendMessage(string message, string level, IDictionary<string, object> customData = null, Action<DataModel> modelAction = null, object userParam = null);
 
-        void Send(DataModel data, object userParam);
+        Task Send(DataModel data, object userParam);
 
         /// <summary>
         /// Serialize the given object for transmission

--- a/src/RollbarSharp/RollbarClient.cs
+++ b/src/RollbarSharp/RollbarClient.cs
@@ -74,9 +74,10 @@ namespace RollbarSharp
         /// <param name="ex"></param>
         /// <param name="title"></param>
         /// <param name="modelAction"></param>
-        public void SendCriticalException(Exception ex, string title = null, Action<DataModel> modelAction = null, object userParam = null)
+        /// <param name="userParam"></param>
+        public Task SendCriticalException(Exception ex, string title = null, Action<DataModel> modelAction = null, object userParam = null)
         {
-            SendException(ex, title, "critical", modelAction);
+            return SendException(ex, title, "critical", modelAction);
         }
 
         /// <summary>
@@ -85,9 +86,10 @@ namespace RollbarSharp
         /// <param name="ex"></param>
         /// <param name="title"></param>
         /// <param name="modelAction"></param>
-        public void SendErrorException(Exception ex, string title = null, Action<DataModel> modelAction = null, object userParam = null)
+        /// <param name="userParam"></param>
+        public Task SendErrorException(Exception ex, string title = null, Action<DataModel> modelAction = null, object userParam = null)
         {
-            SendException(ex, title, "error", modelAction);
+            return SendException(ex, title, "error", modelAction);
         }
 
         /// <summary>
@@ -96,9 +98,10 @@ namespace RollbarSharp
         /// <param name="ex"></param>
         /// <param name="title"></param>
         /// <param name="modelAction"></param>
-        public void SendWarningException(Exception ex, string title = null, Action<DataModel> modelAction = null, object userParam = null)
+        /// <param name="userParam"></param>
+        public Task SendWarningException(Exception ex, string title = null, Action<DataModel> modelAction = null, object userParam = null)
         {
-            SendException(ex, title, "warning", modelAction);
+           return SendException(ex, title, "warning", modelAction);
         }
 
         /// <summary>
@@ -109,14 +112,15 @@ namespace RollbarSharp
         /// <param name="title"></param>
         /// <param name="level">Default is "error". "critical" and "warning" may also make sense to use.</param>
         /// <param name="modelAction"></param>
-        public void SendException(Exception ex, string title = null, string level = "error", Action<DataModel> modelAction = null, object userParam = null)
+        /// <param name="userParam"></param>
+        public Task SendException(Exception ex, string title = null, string level = "error", Action<DataModel> modelAction = null, object userParam = null)
         {
             var notice = NoticeBuilder.CreateExceptionNotice(ex, title, level);
             if (modelAction != null)
             {
                 modelAction(notice);
             }
-            Send(notice, userParam);
+            return Send(notice, userParam);
         }
 
         /// <summary>
@@ -125,9 +129,10 @@ namespace RollbarSharp
         /// <param name="message"></param>
         /// <param name="customData"></param>
         /// <param name="modelAction"></param>
-        public void SendCriticalMessage(string message, IDictionary<string, object> customData = null, Action<DataModel> modelAction = null, object userParam = null)
+        /// <param name="userParam"></param>
+        public Task SendCriticalMessage(string message, IDictionary<string, object> customData = null, Action<DataModel> modelAction = null, object userParam = null)
         {
-            SendMessage(message, "critical", customData, modelAction, userParam);
+            return SendMessage(message, "critical", customData, modelAction, userParam);
         }
 
         /// <summary>
@@ -136,9 +141,10 @@ namespace RollbarSharp
         /// <param name="message"></param>
         /// <param name="customData"></param>
         /// <param name="modelAction"></param>
-        public void SendErrorMessage(string message, IDictionary<string, object> customData = null, Action<DataModel> modelAction = null, object userParam = null)
+        /// <param name="userParam"></param>
+        public Task SendErrorMessage(string message, IDictionary<string, object> customData = null, Action<DataModel> modelAction = null, object userParam = null)
         {
-            SendMessage(message, "error", customData, modelAction, userParam);
+            return SendMessage(message, "error", customData, modelAction, userParam);
         }
 
         /// <summary>
@@ -147,9 +153,10 @@ namespace RollbarSharp
         /// <param name="message"></param>
         /// <param name="customData"></param>
         /// <param name="modelAction"></param>
-        public void SendWarningMessage(string message, IDictionary<string, object> customData = null, Action<DataModel> modelAction = null, object userParam = null)
+        /// <param name="userParam"></param>
+        public Task SendWarningMessage(string message, IDictionary<string, object> customData = null, Action<DataModel> modelAction = null, object userParam = null)
         {
-            SendMessage(message, "warning", customData, modelAction, userParam);
+            return SendMessage(message, "warning", customData, modelAction, userParam);
         }
 
         /// <summary>
@@ -158,9 +165,10 @@ namespace RollbarSharp
         /// <param name="message"></param>
         /// <param name="customData"></param>
         /// <param name="modelAction"></param>
-        public void SendInfoMessage(string message, IDictionary<string, object> customData = null, Action<DataModel> modelAction = null, object userParam = null)
+        /// <param name="userParam"></param>
+        public Task SendInfoMessage(string message, IDictionary<string, object> customData = null, Action<DataModel> modelAction = null, object userParam = null)
         {
-            SendMessage(message, "info", customData, modelAction, userParam);
+            return SendMessage(message, "info", customData, modelAction, userParam);
         }
 
         /// <summary>
@@ -169,9 +177,10 @@ namespace RollbarSharp
         /// <param name="message"></param>
         /// <param name="customData"></param>
         /// <param name="modelAction"></param>
-        public void SendDebugMessage(string message, IDictionary<string, object> customData = null, Action<DataModel> modelAction = null, object userParam = null)
+        /// <param name="userParam"></param>
+        public Task SendDebugMessage(string message, IDictionary<string, object> customData = null, Action<DataModel> modelAction = null, object userParam = null)
         {
-            SendMessage(message, "debug", customData, modelAction);
+            return SendMessage(message, "debug", customData, modelAction);
         }
 
         /// <summary>
@@ -181,20 +190,21 @@ namespace RollbarSharp
         /// <param name="level"></param>
         /// <param name="customData"></param>
         /// <param name="modelAction"></param>
-        public void SendMessage(string message, string level, IDictionary<string, object> customData = null, Action<DataModel> modelAction = null, object userParam = null)
+        /// <param name="userParam"></param>
+        public Task SendMessage(string message, string level, IDictionary<string, object> customData = null, Action<DataModel> modelAction = null, object userParam = null)
         {
             var notice = NoticeBuilder.CreateMessageNotice(message, level, customData);
             if (modelAction != null)
             {
                 modelAction(notice);
             }
-            Send(notice, userParam);
+            return Send(notice, userParam);
         }
 
-        public void Send(DataModel data, object userParam)
+        public Task Send(DataModel data, object userParam)
         {
             var payload = new PayloadModel(Configuration.AccessToken, data);
-            HttpPost(payload, userParam);
+            return HttpPost(payload, userParam);
         }
 
         /// <summary>
@@ -207,15 +217,15 @@ namespace RollbarSharp
             return JsonConvert.SerializeObject(data, Configuration.JsonSettings);
         }
 
-        protected void HttpPost(PayloadModel payload, object userParam)
+        protected Task HttpPost(PayloadModel payload, object userParam)
         {
             var payloadString = Serialize(payload);
-            HttpPost(payloadString, userParam);
+            return HttpPost(payloadString, userParam);
         }
 
-        protected void HttpPost(string payload, object userParam)
+        protected Task HttpPost(string payload, object userParam)
         {
-            Task.Factory.StartNew(() => HttpPostAsync(payload, userParam));
+            return Task.Factory.StartNew(() => HttpPostAsync(payload, userParam));
         }
 
         protected void HttpPostAsync(string payload, object userParam)


### PR DESCRIPTION
I found that in order to use the uuid that the Rollbar API returns after sending a new item, it is necessary to have access to the Task that's created in the HttpPost method, in order to wait for the task to complete.

This is useful when doing something like showing the uuid on the application's error page.
https://rollbar.com/docs/uuids/

This pull request is to change the return type of the send methods from void to Task, so that users of the library can use the Task to manage execution.

Here is an example:

        protected void Application_Error(object sender, EventArgs e)
        {
            // Capture The Error
            Exception ex = Server.GetLastError();
            var exceptionId = "";

            // log the error to Rollbar
            var rollbarClient = new RollbarClient();
            
            // save the uuid when request completes
            rollbarClient.RequestCompleted += (source, args) =>
            {
                var result = args.Result;
                dynamic responseObj = JsonConvert.DeserializeObject(result.RawResponse);
                exceptionId = responseObj.result.uuid;
            };

            var logTask = rollbarClient.SendException(ex);
            // wait for exception logging to finish so we can get the exceptionId
            logTask.Wait(5000);

            // Clear the error
            Server.ClearError();

            // Send to Error Page
            String URL = "/error.aspx?ErrorCode=" + exceptionId;
            Response.Redirect(URL);
        }
