### PR TITLE
FIX: FrameModelBuilder when frame.GetMethod() is null 

### DIFF
--- a/src/RollbarSharp.Tests/Serialization/TraceModelTest.cs
+++ b/src/RollbarSharp.Tests/Serialization/TraceModelTest.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using NUnit.Framework;
 using RollbarSharp.Builders;
+using System.Reflection;
 
 namespace RollbarSharp.Tests.Serialization
 {
@@ -49,11 +50,28 @@ namespace RollbarSharp.Tests.Serialization
             }
         }
 
+		[Test()]
+		public void when_creating_from_thrown_within_reflection_call_exception_should_have_Exception_model()
+		{
+			var method = this.GetType().GetMethod("MethodWithException");
+			try{
+				method.Invoke(this, new object[]{ null});
+				Assert.Fail("La llamada anterior debe lanzar una excepción");
+			}catch(Exception ex){
+				var model = TraceChainModelBuilder.CreateFromException(ex).FirstOrDefault();
+				Assert.IsNotNull(model.Exception);
+			}
+		}
+
         private int GenerateException(string noparam)
         {
             var x = 0;
             var q = 1 / x;
             return q;
         }
+
+		public void MethodWithException(string noparam){
+			throw new ArgumentException("Test exception");
+		}
     }
 }

--- a/src/RollbarSharp.Tests/Serialization/TraceModelTest.cs
+++ b/src/RollbarSharp.Tests/Serialization/TraceModelTest.cs
@@ -58,7 +58,7 @@ namespace RollbarSharp.Tests.Serialization
             try
             {
                 method.Invoke(this, new object[]{ null });
-                Assert.Fail("La llamada anterior debe lanzar una excepción");
+                Assert.Fail("The previous call must throw an exception");
             }
             catch (Exception ex)
             {

--- a/src/RollbarSharp.Tests/Serialization/TraceModelTest.cs
+++ b/src/RollbarSharp.Tests/Serialization/TraceModelTest.cs
@@ -36,6 +36,7 @@ namespace RollbarSharp.Tests.Serialization
                 Assert.Greater(model.Frames.Length, 0);
             }
         }
+
         [Test]
         public void when_creating_from_thrown_exception_should_have_Exception_model()
         {
@@ -50,18 +51,21 @@ namespace RollbarSharp.Tests.Serialization
             }
         }
 
-		[Test()]
-		public void when_creating_from_thrown_within_reflection_call_exception_should_have_Exception_model()
-		{
-			var method = this.GetType().GetMethod("MethodWithException");
-			try{
-				method.Invoke(this, new object[]{ null});
-				Assert.Fail("La llamada anterior debe lanzar una excepción");
-			}catch(Exception ex){
-				var model = TraceChainModelBuilder.CreateFromException(ex).FirstOrDefault();
-				Assert.IsNotNull(model.Exception);
-			}
-		}
+        [Test()]
+        public void when_creating_from_thrown_within_reflection_call_exception_should_have_Exception_model()
+        {
+            var method = this.GetType().GetMethod("MethodWithException");
+            try
+            {
+                method.Invoke(this, new object[]{ null });
+                Assert.Fail("La llamada anterior debe lanzar una excepción");
+            }
+            catch (Exception ex)
+            {
+                var model = TraceChainModelBuilder.CreateFromException(ex).FirstOrDefault();
+                Assert.IsNotNull(model.Exception);
+            }
+        }
 
         private int GenerateException(string noparam)
         {
@@ -70,8 +74,9 @@ namespace RollbarSharp.Tests.Serialization
             return q;
         }
 
-		public void MethodWithException(string noparam){
-			throw new ArgumentException("Test exception");
-		}
+        public void MethodWithException(string noparam)
+        {
+            throw new ArgumentException("Test exception");
+        }
     }
 }

--- a/src/RollbarSharp/Builders/FrameModelBuilder.cs
+++ b/src/RollbarSharp/Builders/FrameModelBuilder.cs
@@ -32,7 +32,6 @@ namespace RollbarSharp.Builders
                 var method = frame.GetMethod();
                 var lineNumber = frame.GetFileLineNumber();
                 var fileName = frame.GetFileName();
-                var methodParams = method.GetParameters();
 
                 // when the line number is zero, you can try using the IL offset
                 if (lineNumber == 0)
@@ -45,22 +44,28 @@ namespace RollbarSharp.Builders
                 if (lineNumber < 0)
                     lineNumber = 0;
 
-                // file names aren't always available, so use the type name instead, if possible
-                if (string.IsNullOrEmpty(fileName))
-                {
-                    fileName = method.ReflectedType != null
-                                   ? method.ReflectedType.FullName
-                                   : "(unknown)";
-                }
+				string methodName;
 
-                var methodName = method.Name;
+				//At least on Mono 4.2.1: on reflection call frame.GetMethod() can be null
+				if (method != null) {
+					// file names aren't always available, so use the type name instead, if possible
+					if (string.IsNullOrEmpty(fileName)) {
+						fileName = method.ReflectedType != null
+	                                   ? method.ReflectedType.FullName
+	                                   : "(unknown)";
+					}
+									
+					methodName = method.Name;
 
-                // add method parameters to the method name. helpful for resolving overloads.
-                if (methodParams.Length > 0)
-                {
-                    var paramDesc = string.Join(", ", methodParams.Select(p => p.ParameterType + " " + p.Name));
-                    methodName = methodName + "(" + paramDesc + ")";
-                }
+					// add method parameters to the method name. helpful for resolving overloads.
+					var methodParams = method.GetParameters();
+					if (methodParams.Length > 0) {
+						var paramDesc = string.Join(", ", methodParams.Select(p => p.ParameterType + " " + p.Name));
+						methodName = methodName + "(" + paramDesc + ")";
+					}
+				} else {
+					methodName = "(unknown)";
+				}
 
                 lines.Add(new FrameModel(fileName, lineNumber, methodName));
             }

--- a/src/RollbarSharp/Builders/FrameModelBuilder.cs
+++ b/src/RollbarSharp/Builders/FrameModelBuilder.cs
@@ -44,28 +44,33 @@ namespace RollbarSharp.Builders
                 if (lineNumber < 0)
                     lineNumber = 0;
 
-				string methodName;
+                string methodName;
 
-				//At least on Mono 4.2.1: on reflection call frame.GetMethod() can be null
-				if (method != null) {
-					// file names aren't always available, so use the type name instead, if possible
-					if (string.IsNullOrEmpty(fileName)) {
-						fileName = method.ReflectedType != null
+                //At least on Mono 4.2.1: on reflection call frame.GetMethod() can be null
+                if (method != null)
+                {
+                    // file names aren't always available, so use the type name instead, if possible
+                    if (string.IsNullOrEmpty(fileName))
+                    {
+                        fileName = method.ReflectedType != null
 	                                   ? method.ReflectedType.FullName
 	                                   : "(unknown)";
-					}
+                    }
 									
-					methodName = method.Name;
+                    methodName = method.Name;
 
-					// add method parameters to the method name. helpful for resolving overloads.
-					var methodParams = method.GetParameters();
-					if (methodParams.Length > 0) {
-						var paramDesc = string.Join(", ", methodParams.Select(p => p.ParameterType + " " + p.Name));
-						methodName = methodName + "(" + paramDesc + ")";
-					}
-				} else {
-					methodName = "(unknown)";
-				}
+                    // add method parameters to the method name. helpful for resolving overloads.
+                    var methodParams = method.GetParameters();
+                    if (methodParams.Length > 0)
+                    {
+                        var paramDesc = string.Join(", ", methodParams.Select(p => p.ParameterType + " " + p.Name));
+                        methodName = methodName + "(" + paramDesc + ")";
+                    }
+                }
+                else
+                {
+                    methodName = "(unknown)";
+                }
 
                 lines.Add(new FrameModel(fileName, lineNumber, methodName));
             }


### PR DESCRIPTION
This happens on Mono 4.2.1 when reflection is involved